### PR TITLE
Escape file names before passing them to the shell

### DIFF
--- a/ftplugin/dot.vim
+++ b/ftplugin/dot.vim
@@ -53,18 +53,18 @@ fu! GraphvizCompile(...)
 	let s:logfile = expand('%:p:r').'.log'
 	" DOT command uses -O option instead of -o because this doesn't work if
 	" there are multiple graphs in the file.
-	let cmd = '!('.g:WMGraphviz_dot.' -O -T'.s:output.' '.g:WMGraphviz_shelloptions.' '.expand('%:p').' 2>&1) | tee '.expand('%:p:r').'.log'
+	let cmd = '!('.g:WMGraphviz_dot.' -O -T'.s:output.' '.g:WMGraphviz_shelloptions.' '.shellescape(expand('%:p')).' 2>&1) | tee '.shellescape(expand('%:p:r').'.log')
 	exec cmd
-	exec 'cfile '.s:logfile
+	exec 'cfile '.escape(s:logfile, ' \"!?''')
 endfu
 
 fu! GraphvizCompileToLaTeX(...)
 	let s:logfile = expand('%:p:r').'.log'
 	" DOT command uses -O option instead of -o because this doesn't work if
 	" there are multiple graphs in the file.
-	let cmd = '!(('.g:WMGraphviz_dot2tex.' '.g:WMGraphviz_dot2texoptions.' '.expand('%:p').' > '.expand('%:p:r').'.tex) 2>&1) | tee '.expand('%:p:r').'.log'
+	let cmd = '!(('.g:WMGraphviz_dot2tex.' '.g:WMGraphviz_dot2texoptions.' '.shellescape(expand('%:p')).' > '.shellescape(expand('%:p:r').'.tex').') 2>&1) | tee '.shellescape(expand('%:p:r').'.log')
 	exec cmd
-	exec 'cfile '.s:logfile
+	exec 'cfile '.escape(s:logfile, ' \"!?''')
 endfu
 
 " Viewing
@@ -72,7 +72,7 @@ fu! GraphvizShow()
 	if !filereadable(expand('%:p').'.pdf')
 		call GraphvizCompile()
 	endif
-	exec '!'.g:WMGraphviz_viewer.' '.expand('%:p').'.pdf'
+	exec '!'.g:WMGraphviz_viewer.' '.shellescape(expand('%:p').'.pdf')
 endfu
 
 " Available functions


### PR DESCRIPTION
Hi!

Thank you for writing a vim plugin for graphviz. :)

You didn't explicitly invite patches, but I noticed that the plugin can't handle filenames with spaces in them, so I used Vim's shellescape() function to fix that. I tried to keep the changes to a minimum and introduced no extra variables (although it may be a good idea to do so at a later time to improve readability), so reviewing the patch should be quick.

Regards,
DataWraith
