### PR TITLE
open viewer from gvim

### DIFF
--- a/ftplugin/dot.vim
+++ b/ftplugin/dot.vim
@@ -90,7 +90,7 @@ fu! GraphvizShow()
 		return
 	endif
 
-	exec '!'.g:WMGraphviz_viewer.' '.shellescape(expand('%:p').'.'.g:WMGraphviz_output)
+	exec '!'.g:WMGraphviz_viewer.' '.shellescape(expand('%:p').'.'.g:WMGraphviz_output).' &'
 endfu
 
 " Available functions


### PR DESCRIPTION
`GraphvizShow` does not work in gvim in ubuntu, but it works with vim in the console. This patch fixes it.
