### PR TITLE
Add :GraphvizInteractive command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Features
 
 * Compiling: `:GraphvizCompile`, `<Leader>ll`
 * Viewing: `:GraphvizShow`, `<Leader>lv`
+* Interactive viewing + editing: `:GraphvizInteractive`, `<Leader>li`
 * Omnicompletion: `<C-X><C-O>`
 * Quickfix window for errors and warnings
 * Snipmate support

--- a/doc/wmgraphviz.txt
+++ b/doc/wmgraphviz.txt
@@ -41,6 +41,10 @@ MAPPINGS                                                 *wmgraphviz-mappings*
 <LocalLeader>lv		|:GraphvizShow|
 	View the graph in the current dot-file.
 
+<LocalLeader>li		|:GraphvizInteractive|
+	Open interactive dot viewer that immediately redraws image when
+	dot-file is saved.
+
 ==============================================================================
 
 COMMANDS                                                 *wmgraphviz-commands*
@@ -58,6 +62,10 @@ COMMANDS                                                 *wmgraphviz-commands*
 
 *:GraphvizShow*
 	View the graph in the current dot-file.
+
+*:GraphvizInteractive*
+	Open interactive dot viewer that immediately redraws image when
+	dot-file is saved.
 
 ==============================================================================
 

--- a/ftplugin/dot.vim
+++ b/ftplugin/dot.vim
@@ -112,6 +112,17 @@ fu! GraphvizShow()
 	exec '!'.g:WMGraphviz_viewer.' '.shellescape(expand('%:p').'.'.g:WMGraphviz_output).' &'
 endfu
 
+" Interactive viewing. "dot -Txlib <file.gv>" uses inotify to immediately
+" redraw image when the input file is changed.
+fu! GraphvizInteractive()
+	if !executable(g:WMGraphviz_dot)
+		echoerr 'The "'.g:WMGraphviz_dot.'" executable was not found.'
+		return
+	endif
+
+	exec '!'.g:WMGraphviz_dot.' -Txlib '.shellescape(expand('%:p')).' &'
+endfu
+
 " Available functions
 com! -nargs=0 GraphvizCompile :call GraphvizCompile(g:WMGraphviz_dot, g:WMGraphviz_output)
 com! -nargs=0 GraphvizCompilePS :call GraphvizCompile(g:WMGraphviz_dot, 'ps')
@@ -125,11 +136,13 @@ com! -nargs=0 GraphvizCompileTwopi :call GraphvizCompile(g:WMGraphviz_twopi, g:W
 com! -nargs=0 GraphvizCompileToLaTeX :call GraphvizCompileToLaTeX()
 
 com! -nargs=0 GraphvizShow : call GraphvizShow()
+com! -nargs=0 GraphvizInteractive : call GraphvizInteractive()
 
 " Mappings
 nmap <silent> <buffer> <LocalLeader>ll :GraphvizCompile<CR>
 nmap <silent> <buffer> <LocalLeader>lt :GraphvizCompileToLaTeX<CR>
 nmap <silent> <buffer> <LocalLeader>lv :GraphvizShow<CR>
+nmap <silent> <buffer> <LocalLeader>li :GraphvizInteractive<CR>
 
 " Completion
 let s:completion_type = ''


### PR DESCRIPTION
:GraphvizInteractive opens a dot viewer that immediately redraws the
image when the source file is saved. This is done with "dot -Txlib", the
same command that the vimdot script from the graphviz package uses.

Tested on Linux (ok) and Windows (not ok; graphviz isn't built with xlib
support).
